### PR TITLE
refactor: replace z.InferType for compatibility

### DIFF
--- a/src/schemaValidations/auth.schema.ts
+++ b/src/schemaValidations/auth.schema.ts
@@ -7,7 +7,7 @@ export const LoginBody = z
   })
   .strict()
 
-export type LoginBodyType = z.TypeOf<typeof LoginBody>
+export type LoginBodyType = z.infer<typeof LoginBody>
 
 export const LoginRes = z.object({
   data: z.object({
@@ -25,7 +25,7 @@ export const LoginRes = z.object({
   message: z.string()
 })
 
-export type LoginResType = z.TypeOf<typeof LoginRes>
+export type LoginResType = z.infer<typeof LoginRes>
 
 export const RegisterBody = z
   .object({
@@ -39,13 +39,13 @@ export const RegisterBody = z
     path: ['confirmPassword']
   })
 
-export type RegisterBodyType = z.TypeOf<typeof RegisterBody>
+export type RegisterBodyType = z.infer<typeof RegisterBody>
 
 export const RegisterRes = z.object({
   message: z.string()
 })
 
-export type RegisterResType = z.TypeOf<typeof RegisterRes>
+export type RegisterResType = z.infer<typeof RegisterRes>
 
 export const RefreshTokenBody = z
   .object({
@@ -53,7 +53,7 @@ export const RefreshTokenBody = z
   })
   .strict()
 
-export type RefreshTokenBodyType = z.TypeOf<typeof RefreshTokenBody>
+export type RefreshTokenBodyType = z.infer<typeof RefreshTokenBody>
 
 export const RefreshTokenRes = z.object({
   data: z.object({
@@ -63,7 +63,7 @@ export const RefreshTokenRes = z.object({
   message: z.string()
 })
 
-export type RefreshTokenResType = z.TypeOf<typeof RefreshTokenRes>
+export type RefreshTokenResType = z.infer<typeof RefreshTokenRes>
 
 export type LogoutBodyType = RefreshTokenBodyType
 
@@ -71,4 +71,4 @@ export const LogoutRes = z.object({
   message: z.string()
 })
 
-export type LogoutResType = z.TypeOf<typeof LogoutRes>
+export type LogoutResType = z.infer<typeof LogoutRes>

--- a/src/schemaValidations/users.schema.ts
+++ b/src/schemaValidations/users.schema.ts
@@ -9,7 +9,7 @@ export const UserSchema = z.object({
   avatar: z.string().nullable()
 })
 
-export type UserType = z.TypeOf<typeof UserSchema>
+export type UserType = z.infer<typeof UserSchema>
 
 export const ChangePasswordBody = z
   .object({
@@ -23,10 +23,10 @@ export const ChangePasswordBody = z
     path: ['confirmNewPassword']
   })
 
-export type ChangePasswordBodyType = z.TypeOf<typeof ChangePasswordBody>
+export type ChangePasswordBodyType = z.infer<typeof ChangePasswordBody>
 
 export const ChangePasswordRes = z.object({
   message: z.string()
 })
 
-export type ChangePasswordResType = z.TypeOf<typeof ChangePasswordRes>
+export type ChangePasswordResType = z.infer<typeof ChangePasswordRes>


### PR DESCRIPTION
- Change the way to get the data type of zod from z.InferType to z.infer